### PR TITLE
Replace BIND9 with DNSmasq

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -8,12 +8,17 @@ RANDOMHAM=$(date +%s|sha256sum|base64|head -c 10)
 RANDOMSPAM=$(date +%s|sha256sum|base64|head -c 10)
 RANDOMVIRUS=$(date +%s|sha256sum|base64|head -c 10)
 ## Installing the DNS Server ##
-echo "Installing DNS Server"
-sudo apt-get update && sudo sudo apt-get install -y bind9 bind9utils bind9-doc dnsutils
+echo "Installing DNSMASQ DNS Server"
+sudo apt-get update && sudo sudo apt-get install -y dnsmasq dnsutils
+## was originally a full "bind9" install
 echo "Configuring DNS Server"
+## START of TODO changes for DNSMASQ
+# TODO: fix settings below
 sed "s/-u/-4 -u/g" /etc/default/bind9 > /etc/default/bind9.new
 mv /etc/default/bind9.new /etc/default/bind9
 rm /etc/bind/named.conf.options
+#TODO: replace named.conf.options with "dnsmasq" equivalents
+# See: www.thekelleys.org.uk/dnsmasq/docs/dnsmasq.conf.example
 cat <<EOF >>/etc/bind/named.conf.options
 options {
 directory "/var/cache/bind";
@@ -58,6 +63,7 @@ imap4     IN      A      $CONTAINERIP
 smtp     IN      A      $CONTAINERIP
 EOF
 sudo service bind9 restart 
+## END OF TODO changes for DNSMASQ
 
 ##Install the Zimbra Collaboration OS dependencies and Zimbra package ##
 apt-get update

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -42,7 +42,7 @@ sudo service dnsmasq restart
 apt-get update
 echo "Download and install Zimbra Collaboration dependencies"
 sudo apt-get install -y netcat-openbsd sudo libidn11 libpcre3 libgmp10 libexpat1 libstdc++6 libperl5.18 libaio1 resolvconf unzip pax sysstat sqlite3
-
+## https://wiki.zimbra.com/wiki/Install_Zimbra_Collaboration_and_a_DNS_Server_with_Script
 ## Building and adding the Scripts keystrokes and the config.defaults
 touch /tmp/zcs/installZimbra-keystrokes
 cat <<EOF >/tmp/zcs/installZimbra-keystrokes


### PR DESCRIPTION
Hi Jorge

This pull-request is primarily a suggestion. I replaced BIND9 with DNSmasq for the following reasons:

Dnsmasq is smaller, less requirements, and allows replacement of individual DNS records without needing to control an entire domain
e.g
Return an MX record named "maildomain.com" with target
servermachine.com and preference 50
''mx-host=maildomain.com,servermachine.com,50''
